### PR TITLE
Add Markdownlint

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,6 +1,6 @@
 name: Testing Workflow
 
-on: [push]
+on: [push, pull_request]
 
 permissions:
   checks: write

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,16 @@
+name: Testing Workflow
+
+on: [push]
+
+permissions:
+  checks: write
+  actions: read
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: articulate/actions-markdownlint@v1

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,4 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: articulate/actions-markdownlint@v1
+      - uses: DavidAnson/markdownlint-cli2-action@v12
+        with:
+          # config: ./markdownlint-cli2.jsonc
+          globs: "**/*.md"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,6 +1,9 @@
 name: Testing Workflow
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    branches: [ main ]
 
 permissions:
   checks: write

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,7 @@
+# This document serves two purposes to allow us to easily keep them in sync.
+# 1) This document is the configuration for the MarkdownLint action.
+# 2) This document is also serves as the documentation style guidelines.
+
 # Default state for all rules
 default: true
 
@@ -19,3 +23,5 @@ MD049:
 # bold with asterisk (`**bold**`)
 MD050:
   style: asterisk
+
+# Each sentence should be on its own line.  This enables easier commenting on individual sentences.  This is not enforced by MarkdownLint.

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,8 +1,5 @@
 # Default state for all rules
 default: true
 
-MD013:
-  # Number of characters
-  line_length: -1
-
+MD013: false
 MD004: false

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,8 @@
+# Default state for all rules
+default: true
+
+MD013:
+  # Number of characters
+  line_length: -1
+
+MD004: false

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,5 +1,21 @@
 # Default state for all rules
 default: true
 
+# all lists use a `-`
+MD004:
+  style: dash
+
+# allow tabs in code blocks (for Go)
+MD010:
+  code_blocks: false
+
+# disable line length, prefer one sentence per line for PRs
 MD013: false
-MD004: false
+
+# emphasis with underscore (`_emphasis_`)
+MD049:
+  style: underscore
+
+# bold with asterisk (`**bold**`)
+MD050:
+  style: asterisk

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,10 @@ The best way to reach us with a question when contributing is to ask on:
 
 ⚠️ **Explain how to set up a development environment**
 
+If using VSCode you will want to install the [MarkdownLint extension](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint).
+
+The style guidelines are documented [here](./.markdownlint.yaml)
+
 ## Sign Your Commits
 
 [Instructions](https://contribute.cncf.io/maintainers/github/templates/required/contributing/#sign-your-commits)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ We welcome many different types of contributions including:
 
 Not everything happens through a GitHub pull request. Please come to our
 [meetings](TODO) or [contact us](TODO) and let's discuss how we can work
-together. 
+together.
 
 ### Come to Meetings
 
@@ -104,6 +104,7 @@ The best way to reach us with a question when contributing is to ask on:
 ⚠️ **Keep either the DCO or CLA section depending on which you use**
 
 ### DCO
+
 Licensing is important to open source projects. It provides some assurances that
 the software will continue to be available based under the terms that the
 author(s) desired. We require that contributors sign off on commits submitted to
@@ -123,12 +124,13 @@ Git has a `-s` command line option to do this automatically:
     git commit -s -m 'This is my commit message'
 
 If you forgot to do this and have not yet pushed your changes to the remote
-repository, you can amend your commit with the sign-off by running 
+repository, you can amend your commit with the sign-off by running
 
     git commit --amend -s 
 
 ### CLA
-We require that contributors have signed our Contributor License Agreement (CLA). 
+
+We require that contributors have signed our Contributor License Agreement (CLA).
 
 ⚠️ **Explain how to sign the CLA**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,23 +2,23 @@
 
 [Instructions](https://contribute.cncf.io/maintainers/github/templates/required/contributing/#introduction)
 
-* [New Contributor Guide](#contributing-guide)
-  * [Ways to Contribute](#ways-to-contribute)
-  * [Find an Issue](#find-an-issue)
-  * [Ask for Help](#ask-for-help)
-  * [Pull Request Lifecycle](#pull-request-lifecycle)
-  * [Development Environment Setup](#development-environment-setup)
-  * [Sign Your Commits](#sign-your-commits)
-  * [Pull Request Checklist](#pull-request-checklist)
+- [New Contributor Guide](#contributing-guide)
+  - [Ways to Contribute](#ways-to-contribute)
+  - [Find an Issue](#find-an-issue)
+  - [Ask for Help](#ask-for-help)
+  - [Pull Request Lifecycle](#pull-request-lifecycle)
+  - [Development Environment Setup](#development-environment-setup)
+  - [Sign Your Commits](#sign-your-commits)
+  - [Pull Request Checklist](#pull-request-checklist)
 
 Welcome! We are glad that you want to contribute to our project! 💖
 
 As you get started, you are in the best position to give us feedback on areas of
 our project that we need help with including:
 
-* Problems found during setting up a new developer environment
-* Gaps in our Quickstart Guide or documentation
-* Bugs in our automation scripts
+- Problems found during setting up a new developer environment
+- Gaps in our Quickstart Guide or documentation
+- Bugs in our automation scripts
 
 If anything doesn't make sense, or doesn't work when you run it, please open a
 bug report and let us know!
@@ -29,15 +29,15 @@ bug report and let us know!
 
 We welcome many different types of contributions including:
 
-* New features
-* Builds, CI/CD
-* Bug fixes
-* Documentation
-* Issue Triage
-* Answering questions on Slack/Mailing List
-* Web design
-* Communications / Social Media / Blog Posts
-* Release management
+- New features
+- Builds, CI/CD
+- Bug fixes
+- Documentation
+- Issue Triage
+- Answering questions on Slack/Mailing List
+- Web design
+- Communications / Social Media / Blog Posts
+- Release management
 
 Not everything happens through a GitHub pull request. Please come to our
 [meetings](TODO) or [contact us](TODO) and let's discuss how we can work
@@ -81,9 +81,9 @@ The best way to reach us with a question when contributing is to ask on:
 
 ⚠️ **Pick the way(s) that you prefer people ask for help**
 
-* The original github issue
-* The developer mailing list
-* Our Slack channel
+- The original github issue
+- The developer mailing list
+- Our Slack channel
 
 ## Pull Request Lifecycle
 

--- a/CONTRIBUTOR_LADDER.md
+++ b/CONTRIBUTOR_LADDER.md
@@ -4,27 +4,24 @@ This is a light contributor ladder template for CNCF projects that requires edit
 
 Particularly, this file provides you with a menu of options for your project.  Most projects have 3-4 defined contributor roles. We have outlined more roles below than you may need, so select what makes sense for the structure and size of your project. Other roles should be deleted, or combined into an adjacent role.
 
-
 <!-- template begins here -->
 
 * [Contributor Ladder](#contributor-ladder-template)
-    * [Community Participant](#community-participant)
-    * [Contributor](#contributor)
-    * [Organization Member](#organization-member)
-    * [Reviewer](#reviewer)
-    * [Maintainer](#maintainer)
+  * [Community Participant](#community-participant)
+  * [Contributor](#contributor)
+  * [Organization Member](#organization-member)
+  * [Reviewer](#reviewer)
+  * [Maintainer](#maintainer)
 * [Inactivity](#inactivity)
 * [Involuntary Removal](#involuntary-removal-or-demotion)
 * [Stepping Down/Emeritus Process](#stepping-downemeritus-process)
 * [Contact](#contact)
-
 
 ## Contributor Ladder
 
 Hello! We are excited that you want to learn more about our project contributor ladder! This contributor ladder outlines the different contributor roles within the project, along with the responsibilities and privileges that come with them. Community members generally start at the first levels of the "ladder" and advance up it as their involvement in the project grows.  Our project members are happy to help you advance along the contributor ladder.
 
 Each of the contributor roles below is organized into lists of three types of things. "Responsibilities" are things that a contributor is expected to do. "Requirements" are qualifications a person needs to meet to be in that role, and "Privileges" are things contributors on that level are entitled to.
-
 
 ### Community Participant
 <!--This role spells out what's expected of general community participants.  This is the lowest
@@ -34,16 +31,15 @@ define it and leave this section out.-->
 Description: A Community Participant engages with the project and its community, contributing their time, thoughts, etc. Community participants are usually users who have stopped being anonymous and started being active in project discussions.
 
 * Responsibilities:
-    * Must follow the [CNCF CoC](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
+  * Must follow the [CNCF CoC](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
 * How users can get involved with the community:
-    * Participating in community discussions
-    * Helping other users
-    * Submitting bug reports
-    * Commenting on issues
-    * Trying out new releases
-    * Attending community events
-    * [TODO: Other examples of non-contribution participation]
-
+  * Participating in community discussions
+  * Helping other users
+  * Submitting bug reports
+  * Commenting on issues
+  * Trying out new releases
+  * Attending community events
+  * [TODO: Other examples of non-contribution participation]
 
 ### Contributor
 <!-- This role describes people who have just started contributing, or who contribute occasionally but don't participate in project governance or have defined responsibilities.  Usually projects define either this level or Community Participant, but not both.  If you don't define this role, make sure to copy over its requirements to Organization Member -->
@@ -51,24 +47,23 @@ Description: A Community Participant engages with the project and its community,
 Description: A Contributor contributes directly to the project and adds value to it. Contributions need not be code. People at the Contributor level may be new contributors, or they may only contribute occasionally.
 
 * Responsibilities include:
-    * Follow the CNCF CoC
-    * Follow the project contributing guide
+  * Follow the CNCF CoC
+  * Follow the project contributing guide
 * Requirements (one or several of the below):
-    * Report and sometimes resolve issues
-    * Occasionally submit PRs
-    * Contribute to the documentation
-    * Show up at meetings, takes notes
-    * Answer questions from other community members
-    * Submit feedback on issues and PRs
-    * Test releases and patches and submit reviews
-    * Run or helps run events
-    * Promote the project in public
-    * Help run the project infrastructure
-    * [TODO: other small contributions]
+  * Report and sometimes resolve issues
+  * Occasionally submit PRs
+  * Contribute to the documentation
+  * Show up at meetings, takes notes
+  * Answer questions from other community members
+  * Submit feedback on issues and PRs
+  * Test releases and patches and submit reviews
+  * Run or helps run events
+  * Promote the project in public
+  * Help run the project infrastructure
+  * [TODO: other small contributions]
 * Privileges:
-    * Invitations to contributor events
-    * Eligible to become an Organization Member
-
+  * Invitations to contributor events
+  * Eligible to become an Organization Member
 
 ### Organization Member
 <!--This role is used by many projects where you have to be a regular contributor to have the right to vote in project elections, or to be able to operate project
@@ -80,27 +75,26 @@ Description: An Organization Member is an established contributor who regularly 
 An Organization Member must meet the responsibilities and has the requirements of a Contributor, plus:
 
 * Responsibilities include:
-    * Continues to contribute regularly, as demonstrated by having at least [TODO: Number] [TODO: Metric] a year, as demonstrated by [TODO: contributor metrics source]. <!-- Example: "as demonstrated by having at least 50 GitHub contributions per year, as shown by Devstats"-->
+  * Continues to contribute regularly, as demonstrated by having at least [TODO: Number] [TODO: Metric] a year, as demonstrated by [TODO: contributor metrics source]. <!-- Example: "as demonstrated by having at least 50 GitHub contributions per year, as shown by Devstats"-->
 * Requirements:
-    * Must have successful contributions to the project, including at least one of the following:
-        * [TODO: Number] accepted PRs,
-        * Reviewed [TODO: Number] PRs,
-        * Resolved and closed [TODO: Number] Issues,
-        * Become responsible for a key project management area,
-        * Or some equivalent combination or contribution
-    * Must have been contributing for at least [TODO: Number] months
-    * Must be actively contributing to at least one project area
-    * Must have two sponsors who are also Organization Members, at least one of whom does not work for the same employer
-    * [TODO: other requirements] <!--TODO: such as repository access or enabling 2FA on their GitHub account -->
+  * Must have successful contributions to the project, including at least one of the following:
+    * [TODO: Number] accepted PRs,
+    * Reviewed [TODO: Number] PRs,
+    * Resolved and closed [TODO: Number] Issues,
+    * Become responsible for a key project management area,
+    * Or some equivalent combination or contribution
+  * Must have been contributing for at least [TODO: Number] months
+  * Must be actively contributing to at least one project area
+  * Must have two sponsors who are also Organization Members, at least one of whom does not work for the same employer
+  * [TODO: other requirements] <!--TODO: such as repository access or enabling 2FA on their GitHub account -->
 
 * Privileges:
-    * May be assigned Issues and Reviews
-    * May give commands to CI/CD automation
-    * Entitled to vote in the [TODO: appropriate election]
-    * Can be added to [TODO: Repo Host] teams
-    * Can recommend other contributors to become Org Members
-    * [TODO: Other Privileges]
-
+  * May be assigned Issues and Reviews
+  * May give commands to CI/CD automation
+  * Entitled to vote in the [TODO: appropriate election]
+  * Can be added to [TODO: Repo Host] teams
+  * Can recommend other contributors to become Org Members
+  * [TODO: Other Privileges]
 
 The process for a Contributor to become an Organization Member is as follows:
 
@@ -119,30 +113,28 @@ Reviewers are responsible for a "specific area." This can be a specific code dir
 Reviewers have all the rights and responsibilities of an Organization Member, plus:
 
 * Responsibilities include:
-    * Following the reviewing guide
-    * Reviewing most Pull Requests against their specific areas of responsibility
-    * Reviewing at least [TODO: Number] PRs per year
-    * Helping other contributors become reviewers
+  * Following the reviewing guide
+  * Reviewing most Pull Requests against their specific areas of responsibility
+  * Reviewing at least [TODO: Number] PRs per year
+  * Helping other contributors become reviewers
 * Requirements:
-    * Experience as a Contributor for at least [TODO: Number] months
-    * Is an Organization Member
-    * Has reviewed, or helped review, at least [TODO: Number] Pull Requests
-    * Has analyzed and resolved test failures in their specific area
-    * Has demonstrated an in-depth knowledge of the specific area
-    * Commits to being responsible for that specific area
-    * Is supportive of new and occasional contributors and helps get useful PRs in shape to commit
+  * Experience as a Contributor for at least [TODO: Number] months
+  * Is an Organization Member
+  * Has reviewed, or helped review, at least [TODO: Number] Pull Requests
+  * Has analyzed and resolved test failures in their specific area
+  * Has demonstrated an in-depth knowledge of the specific area
+  * Commits to being responsible for that specific area
+  * Is supportive of new and occasional contributors and helps get useful PRs in shape to commit
 * Additional privileges:
-    * Has GitHub or CI/CD rights to approve pull requests in specific directories
-    * Can recommend and review other contributors to become Reviewers
-    
+  * Has GitHub or CI/CD rights to approve pull requests in specific directories
+  * Can recommend and review other contributors to become Reviewers
+  
 <!-- TODO: define how this works with your specific system.  For example:  "Is listed as Approver in the OWNERS file for certain directories. -->
-
 
 The process of becoming a Reviewer is:
 <!-- TODO: define your exact process here.  What's below is given as an example process for a project that uses Owners files and has defined teams for each project area -->
 1. The contributor is nominated by opening a PR against the appropriate repository, which adds their GitHub username to the OWNERS file for one or more directories.
 2. At least two members of the team that owns that repository or main directory, who are already Approvers, approve the PR.
-
 
 ### Maintainer
 <!-- In the simplest and most common project structures, projects have a single pool of "maintainers" who are collectively responsible for the entire project.  This example defines that role for your project.  If your project has a more complex structure, see the list of specific maintainer roles you might want to define, below. -->
@@ -153,25 +145,24 @@ Description: Maintainers are very established contributors who are responsible f
 A Maintainer must meet the responsibilities and requirements of a Reviewer, plus:
 
 * Responsibilities include:
-    * Reviewing at least [TODO: Number] PRs per year, especially PRs that involve multiple parts of the project
-    * Mentoring new Reviewers
-    * Writing refactoring PRs
-    * Participating in CNCF maintainer activities
-    * Determining strategy and policy for the project
-    * Participating in, and leading, community meetings
+  * Reviewing at least [TODO: Number] PRs per year, especially PRs that involve multiple parts of the project
+  * Mentoring new Reviewers
+  * Writing refactoring PRs
+  * Participating in CNCF maintainer activities
+  * Determining strategy and policy for the project
+  * Participating in, and leading, community meetings
 * Requirements
-    * Experience as a Reviewer for at least [TODO: Number] months
-    * Demonstrates a broad knowledge of the project across multiple areas
-    * Is able to exercise judgment for the good of the project, independent of their employer, friends, or team
-    * Mentors other contributors
-    * Can commit to spending at least [TODO: Number] hours per month working on the project
+  * Experience as a Reviewer for at least [TODO: Number] months
+  * Demonstrates a broad knowledge of the project across multiple areas
+  * Is able to exercise judgment for the good of the project, independent of their employer, friends, or team
+  * Mentors other contributors
+  * Can commit to spending at least [TODO: Number] hours per month working on the project
 * Additional privileges:
-    * Approve PRs to any area of the project
-    * Represent the project in public as a Maintainer
-    * Communicate with the CNCF on behalf of the project
-    * Have a vote in Maintainer decision-making meetings
-    
-
+  * Approve PRs to any area of the project
+  * Represent the project in public as a Maintainer
+  * Communicate with the CNCF on behalf of the project
+  * Have a vote in Maintainer decision-making meetings
+  
 Process of becoming a maintainer:
 <!-- TODO: this process will vary widely across projects, both because of project code structure, and because of project governance.  For example, in some projects the Steering Committee approves new Maintainers.  What's below is just an example from a simple project in which the maintainers are also the project leaders, and which uses GitHub OWNERS files. -->
 1. Any current Maintainer may nominate a current Reviewer to become a new Maintainer, by opening a PR against the root of the [TODO: main repository name] adding the nominee as an Approver in the OWNERS file.
@@ -182,7 +173,6 @@ Process of becoming a maintainer:
 reached the stage where you have a reasonable diversity of maintainers.  At that point, you can add a statement like this: 
 The maintainers will avoid nominating new maintainers from any organization that already employs 50% or more of existing maintainers
 -->
-
 
 <!-- ### ADDITIONAL MAINTAINER ROLES
 Some projects have additional, specifically defined maintainer roles because of leadership positions that don't fit within the general maintainer template above, including ones that have special requirements.  In addition to spelling out those requirements, defining and publishing additional maintainer roles can be a way to recruit maintainers in those specific areas, especially non-code maintainers.  Here are examples of special maintainer roles which have been defined by a variety of projects.  As all of these roles are highly dependent on exact project organization, tooling, etc., these roles are not templatable.
@@ -196,17 +186,16 @@ Some projects have additional, specifically defined maintainer roles because of 
 * Community Manager: owns social media, community metrics, new contributor process, and similar areas.
 -->
 
-
 ## Inactivity
 <!--TODO: project leads to fill in exact details for how you measure inactivity for your project-->
 It is important for contributors to be and stay active to set an example and show commitment to the project. Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a lost of trust in the project.
 
 * Inactivity is measured by:
-    * Periods of no contributions for longer than [TODO: Number] months
-    * Periods of no communication for longer than [TODO: Number] months
+  * Periods of no contributions for longer than [TODO: Number] months
+  * Periods of no communication for longer than [TODO: Number] months
 * Consequences of being inactive include:
-    * Involuntary removal or demotion
-    * Being asked to move to Emeritus status
+  * Involuntary removal or demotion
+  * Being asked to move to Emeritus status
 
 ## Involuntary Removal or Demotion
 
@@ -217,10 +206,12 @@ Again, the example below is for a project without formal governance except the m
 Involuntary removal or demotion is handled through a vote by a majority of the current Maintainers.
 
 ## Stepping Down/Emeritus Process
+
 If and when contributors' commitment levels change, contributors can consider stepping down (moving down the contributor ladder) vs moving to emeritus status (completely stepping away from the project).
 
 Contact the Maintainers about changing to Emeritus status, or reducing your contributor level.
 
 ## Contact
+
 * For inquiries, please reach out to:
-    *  <!-- TODO: fill in contact info for appropriate group or person for contributor mentorship-->
+  * <!-- TODO: fill in contact info for appropriate group or person for contributor mentorship-->

--- a/CONTRIBUTOR_LADDER.md
+++ b/CONTRIBUTOR_LADDER.md
@@ -6,16 +6,16 @@ Particularly, this file provides you with a menu of options for your project.  M
 
 <!-- template begins here -->
 
-* [Contributor Ladder](#contributor-ladder-template)
-  * [Community Participant](#community-participant)
-  * [Contributor](#contributor)
-  * [Organization Member](#organization-member)
-  * [Reviewer](#reviewer)
-  * [Maintainer](#maintainer)
-* [Inactivity](#inactivity)
-* [Involuntary Removal](#involuntary-removal-or-demotion)
-* [Stepping Down/Emeritus Process](#stepping-downemeritus-process)
-* [Contact](#contact)
+- [Contributor Ladder](#contributor-ladder-template)
+  - [Community Participant](#community-participant)
+  - [Contributor](#contributor)
+  - [Organization Member](#organization-member)
+  - [Reviewer](#reviewer)
+  - [Maintainer](#maintainer)
+- [Inactivity](#inactivity)
+- [Involuntary Removal](#involuntary-removal-or-demotion)
+- [Stepping Down/Emeritus Process](#stepping-downemeritus-process)
+- [Contact](#contact)
 
 ## Contributor Ladder
 
@@ -30,40 +30,40 @@ define it and leave this section out.-->
 <!--TODO: project leads to fill in exact details of this role for your project-->
 Description: A Community Participant engages with the project and its community, contributing their time, thoughts, etc. Community participants are usually users who have stopped being anonymous and started being active in project discussions.
 
-* Responsibilities:
-  * Must follow the [CNCF CoC](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
-* How users can get involved with the community:
-  * Participating in community discussions
-  * Helping other users
-  * Submitting bug reports
-  * Commenting on issues
-  * Trying out new releases
-  * Attending community events
-  * [TODO: Other examples of non-contribution participation]
+- Responsibilities:
+  - Must follow the [CNCF CoC](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
+- How users can get involved with the community:
+  - Participating in community discussions
+  - Helping other users
+  - Submitting bug reports
+  - Commenting on issues
+  - Trying out new releases
+  - Attending community events
+  - [TODO: Other examples of non-contribution participation]
 
 ### Contributor
 <!-- This role describes people who have just started contributing, or who contribute occasionally but don't participate in project governance or have defined responsibilities.  Usually projects define either this level or Community Participant, but not both.  If you don't define this role, make sure to copy over its requirements to Organization Member -->
 <!--TODO: project leads to fill in exact details of this role for your project-->
 Description: A Contributor contributes directly to the project and adds value to it. Contributions need not be code. People at the Contributor level may be new contributors, or they may only contribute occasionally.
 
-* Responsibilities include:
-  * Follow the CNCF CoC
-  * Follow the project contributing guide
-* Requirements (one or several of the below):
-  * Report and sometimes resolve issues
-  * Occasionally submit PRs
-  * Contribute to the documentation
-  * Show up at meetings, takes notes
-  * Answer questions from other community members
-  * Submit feedback on issues and PRs
-  * Test releases and patches and submit reviews
-  * Run or helps run events
-  * Promote the project in public
-  * Help run the project infrastructure
-  * [TODO: other small contributions]
-* Privileges:
-  * Invitations to contributor events
-  * Eligible to become an Organization Member
+- Responsibilities include:
+  - Follow the CNCF CoC
+  - Follow the project contributing guide
+- Requirements (one or several of the below):
+  - Report and sometimes resolve issues
+  - Occasionally submit PRs
+  - Contribute to the documentation
+  - Show up at meetings, takes notes
+  - Answer questions from other community members
+  - Submit feedback on issues and PRs
+  - Test releases and patches and submit reviews
+  - Run or helps run events
+  - Promote the project in public
+  - Help run the project infrastructure
+  - [TODO: other small contributions]
+- Privileges:
+  - Invitations to contributor events
+  - Eligible to become an Organization Member
 
 ### Organization Member
 <!--This role is used by many projects where you have to be a regular contributor to have the right to vote in project elections, or to be able to operate project
@@ -74,27 +74,27 @@ Description: An Organization Member is an established contributor who regularly 
 
 An Organization Member must meet the responsibilities and has the requirements of a Contributor, plus:
 
-* Responsibilities include:
-  * Continues to contribute regularly, as demonstrated by having at least [TODO: Number] [TODO: Metric] a year, as demonstrated by [TODO: contributor metrics source]. <!-- Example: "as demonstrated by having at least 50 GitHub contributions per year, as shown by Devstats"-->
-* Requirements:
-  * Must have successful contributions to the project, including at least one of the following:
-    * [TODO: Number] accepted PRs,
-    * Reviewed [TODO: Number] PRs,
-    * Resolved and closed [TODO: Number] Issues,
-    * Become responsible for a key project management area,
-    * Or some equivalent combination or contribution
-  * Must have been contributing for at least [TODO: Number] months
-  * Must be actively contributing to at least one project area
-  * Must have two sponsors who are also Organization Members, at least one of whom does not work for the same employer
-  * [TODO: other requirements] <!--TODO: such as repository access or enabling 2FA on their GitHub account -->
+- Responsibilities include:
+  - Continues to contribute regularly, as demonstrated by having at least [TODO: Number] [TODO: Metric] a year, as demonstrated by [TODO: contributor metrics source]. <!-- Example: "as demonstrated by having at least 50 GitHub contributions per year, as shown by Devstats"-->
+- Requirements:
+  - Must have successful contributions to the project, including at least one of the following:
+    - [TODO: Number] accepted PRs,
+    - Reviewed [TODO: Number] PRs,
+    - Resolved and closed [TODO: Number] Issues,
+    - Become responsible for a key project management area,
+    - Or some equivalent combination or contribution
+  - Must have been contributing for at least [TODO: Number] months
+  - Must be actively contributing to at least one project area
+  - Must have two sponsors who are also Organization Members, at least one of whom does not work for the same employer
+  - [TODO: other requirements] <!--TODO: such as repository access or enabling 2FA on their GitHub account -->
 
-* Privileges:
-  * May be assigned Issues and Reviews
-  * May give commands to CI/CD automation
-  * Entitled to vote in the [TODO: appropriate election]
-  * Can be added to [TODO: Repo Host] teams
-  * Can recommend other contributors to become Org Members
-  * [TODO: Other Privileges]
+- Privileges:
+  - May be assigned Issues and Reviews
+  - May give commands to CI/CD automation
+  - Entitled to vote in the [TODO: appropriate election]
+  - Can be added to [TODO: Repo Host] teams
+  - Can recommend other contributors to become Org Members
+  - [TODO: Other Privileges]
 
 The process for a Contributor to become an Organization Member is as follows:
 
@@ -112,22 +112,22 @@ Reviewers are responsible for a "specific area." This can be a specific code dir
 
 Reviewers have all the rights and responsibilities of an Organization Member, plus:
 
-* Responsibilities include:
-  * Following the reviewing guide
-  * Reviewing most Pull Requests against their specific areas of responsibility
-  * Reviewing at least [TODO: Number] PRs per year
-  * Helping other contributors become reviewers
-* Requirements:
-  * Experience as a Contributor for at least [TODO: Number] months
-  * Is an Organization Member
-  * Has reviewed, or helped review, at least [TODO: Number] Pull Requests
-  * Has analyzed and resolved test failures in their specific area
-  * Has demonstrated an in-depth knowledge of the specific area
-  * Commits to being responsible for that specific area
-  * Is supportive of new and occasional contributors and helps get useful PRs in shape to commit
-* Additional privileges:
-  * Has GitHub or CI/CD rights to approve pull requests in specific directories
-  * Can recommend and review other contributors to become Reviewers
+- Responsibilities include:
+  - Following the reviewing guide
+  - Reviewing most Pull Requests against their specific areas of responsibility
+  - Reviewing at least [TODO: Number] PRs per year
+  - Helping other contributors become reviewers
+- Requirements:
+  - Experience as a Contributor for at least [TODO: Number] months
+  - Is an Organization Member
+  - Has reviewed, or helped review, at least [TODO: Number] Pull Requests
+  - Has analyzed and resolved test failures in their specific area
+  - Has demonstrated an in-depth knowledge of the specific area
+  - Commits to being responsible for that specific area
+  - Is supportive of new and occasional contributors and helps get useful PRs in shape to commit
+- Additional privileges:
+  - Has GitHub or CI/CD rights to approve pull requests in specific directories
+  - Can recommend and review other contributors to become Reviewers
   
 <!-- TODO: define how this works with your specific system.  For example:  "Is listed as Approver in the OWNERS file for certain directories. -->
 
@@ -144,24 +144,24 @@ Description: Maintainers are very established contributors who are responsible f
 
 A Maintainer must meet the responsibilities and requirements of a Reviewer, plus:
 
-* Responsibilities include:
-  * Reviewing at least [TODO: Number] PRs per year, especially PRs that involve multiple parts of the project
-  * Mentoring new Reviewers
-  * Writing refactoring PRs
-  * Participating in CNCF maintainer activities
-  * Determining strategy and policy for the project
-  * Participating in, and leading, community meetings
-* Requirements
-  * Experience as a Reviewer for at least [TODO: Number] months
-  * Demonstrates a broad knowledge of the project across multiple areas
-  * Is able to exercise judgment for the good of the project, independent of their employer, friends, or team
-  * Mentors other contributors
-  * Can commit to spending at least [TODO: Number] hours per month working on the project
-* Additional privileges:
-  * Approve PRs to any area of the project
-  * Represent the project in public as a Maintainer
-  * Communicate with the CNCF on behalf of the project
-  * Have a vote in Maintainer decision-making meetings
+- Responsibilities include:
+  - Reviewing at least [TODO: Number] PRs per year, especially PRs that involve multiple parts of the project
+  - Mentoring new Reviewers
+  - Writing refactoring PRs
+  - Participating in CNCF maintainer activities
+  - Determining strategy and policy for the project
+  - Participating in, and leading, community meetings
+- Requirements
+  - Experience as a Reviewer for at least [TODO: Number] months
+  - Demonstrates a broad knowledge of the project across multiple areas
+  - Is able to exercise judgment for the good of the project, independent of their employer, friends, or team
+  - Mentors other contributors
+  - Can commit to spending at least [TODO: Number] hours per month working on the project
+- Additional privileges:
+  - Approve PRs to any area of the project
+  - Represent the project in public as a Maintainer
+  - Communicate with the CNCF on behalf of the project
+  - Have a vote in Maintainer decision-making meetings
   
 Process of becoming a maintainer:
 <!-- TODO: this process will vary widely across projects, both because of project code structure, and because of project governance.  For example, in some projects the Steering Committee approves new Maintainers.  What's below is just an example from a simple project in which the maintainers are also the project leaders, and which uses GitHub OWNERS files. -->
@@ -177,25 +177,25 @@ The maintainers will avoid nominating new maintainers from any organization that
 <!-- ### ADDITIONAL MAINTAINER ROLES
 Some projects have additional, specifically defined maintainer roles because of leadership positions that don't fit within the general maintainer template above, including ones that have special requirements.  In addition to spelling out those requirements, defining and publishing additional maintainer roles can be a way to recruit maintainers in those specific areas, especially non-code maintainers.  Here are examples of special maintainer roles which have been defined by a variety of projects.  As all of these roles are highly dependent on exact project organization, tooling, etc., these roles are not templatable.
 
-* Subproject Maintainer: Owns a distinct subproject or repository of the main project.  Responsible for everything there.  In federation projects, subproject maintainers might be the primary maintainer type.  [Example](https://github.com/kubernetes/community/blob/master/committee-steering/governance/sig-governance.md#subproject-owner)
-* Documentation Maintainer: for your Docs leads.  Would include specific documentation targets and experience, and maintaining publication schedules as a requirement.  [Example](https://kubernetes.io/docs/contribute/participate/roles-and-responsibilities/)
-* Localizations Maintainers: owns a particular localization, like Japanese or Brazilian Portuguese, across documentation, messages, and websites.  Responsible for making sure those get updated.
-* Program Manager: Responsible for timelines and processes within the project, such as bug triage, review timelines, etc.
-* Release Manager: owns the release process, either always, cyclically, or per-release.  Responsible for getting releases out on time.  [Example](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-team-lead)
-* Patch Maintainer: sometimes different from the release manager, owns the tooling, team, and schedule for patching stable releases. [Example](https://github.com/kubernetes/sig-release/blob/master/release-engineering/role-handbooks/patch-release-team.md)
-* Community Manager: owns social media, community metrics, new contributor process, and similar areas.
+- Subproject Maintainer: Owns a distinct subproject or repository of the main project.  Responsible for everything there.  In federation projects, subproject maintainers might be the primary maintainer type.  [Example](https://github.com/kubernetes/community/blob/master/committee-steering/governance/sig-governance.md#subproject-owner)
+- Documentation Maintainer: for your Docs leads.  Would include specific documentation targets and experience, and maintaining publication schedules as a requirement.  [Example](https://kubernetes.io/docs/contribute/participate/roles-and-responsibilities/)
+- Localizations Maintainers: owns a particular localization, like Japanese or Brazilian Portuguese, across documentation, messages, and websites.  Responsible for making sure those get updated.
+- Program Manager: Responsible for timelines and processes within the project, such as bug triage, review timelines, etc.
+- Release Manager: owns the release process, either always, cyclically, or per-release.  Responsible for getting releases out on time.  [Example](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-team-lead)
+- Patch Maintainer: sometimes different from the release manager, owns the tooling, team, and schedule for patching stable releases. [Example](https://github.com/kubernetes/sig-release/blob/master/release-engineering/role-handbooks/patch-release-team.md)
+- Community Manager: owns social media, community metrics, new contributor process, and similar areas.
 -->
 
 ## Inactivity
 <!--TODO: project leads to fill in exact details for how you measure inactivity for your project-->
 It is important for contributors to be and stay active to set an example and show commitment to the project. Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a lost of trust in the project.
 
-* Inactivity is measured by:
-  * Periods of no contributions for longer than [TODO: Number] months
-  * Periods of no communication for longer than [TODO: Number] months
-* Consequences of being inactive include:
-  * Involuntary removal or demotion
-  * Being asked to move to Emeritus status
+- Inactivity is measured by:
+  - Periods of no contributions for longer than [TODO: Number] months
+  - Periods of no communication for longer than [TODO: Number] months
+- Consequences of being inactive include:
+  - Involuntary removal or demotion
+  - Being asked to move to Emeritus status
 
 ## Involuntary Removal or Demotion
 
@@ -213,5 +213,5 @@ Contact the Maintainers about changing to Emeritus status, or reducing your cont
 
 ## Contact
 
-* For inquiries, please reach out to:
-  * <!-- TODO: fill in contact info for appropriate group or person for contributor mentorship-->
+- For inquiries, please reach out to:
+  - <!-- TODO: fill in contact info for appropriate group or person for contributor mentorship-->

--- a/DESIGN-PROPOSALS.md
+++ b/DESIGN-PROPOSALS.md
@@ -1,10 +1,10 @@
 # Design Proposal Template
 
-**Authors**: alice alice@example.com, bob jones bob@example.com
+**Authors**: alice <alice@example.com>, bob jones <bob@example.com>
 
 **Begin Design Discussion**: YYYY-MM-DD
 
-**(optional) Status: **implementable, accepted, deferred, rejected, withdrawn, or replaced
+**(optional) Status:** implementable, accepted, deferred, rejected, withdrawn, or replaced
 
 **Checklist**:
 
@@ -17,8 +17,6 @@ What goes in this checklist is highly dependent on how your project manages thei
 - [ ] Docs
 - [ ] Tests
 
-
-
 ## Summary/Abstract
 
 Provide a high-level summary of the proposed change. Keep it short.
@@ -29,11 +27,11 @@ This design process establishes a series of standard practices for planning and 
 
 ### Motivation and problem space
 
-Describe the need, problem, and motivation for the feature or change and any context required to understand the motivation. 
+Describe the need, problem, and motivation for the feature or change and any context required to understand the motivation.
 
 ### Impact and desired outcome
 
-Describe any potential impact this feature or change would have. Readers should be able to understand why the feature or change is important. Briefly describe the desired outcome if the change or feature were implemented as designed. 
+Describe any potential impact this feature or change would have. Readers should be able to understand why the feature or change is important. Briefly describe the desired outcome if the change or feature were implemented as designed.
 
 ### Prior discussion and links
 
@@ -62,13 +60,14 @@ This is where we get down to the specifics of what the proposal actually is. It 
 ## Design Details
 
 This section should contain enough information to allow the following to occur:
+
 * potential contributors understand how the feature or change should be implemented
 * users or operators understand how the feature of change is expected to function and interact with other components of the project
 * users or operators can take action to pre-plan any needed changes within their architecture that impacted by the upcoming feature or change if it's approved for implementation
 * decisions or opinions on a specific approach are fully discussed and explained
 * users, operators, and contributors can gain a comprehensive understanding of compatibility of the feature or change with past releases of the project.
 
-This may include API specs (though not always required), code snippets, data flow diagrams, sequence diagrams, etc. 
+This may include API specs (though not always required), code snippets, data flow diagrams, sequence diagrams, etc.
 
 If there's any ambiguity about HOW your proposal will be implemented, this is the place to discuss them. This can also be combined with the proposal section above. It should also address how the solution is backward compatible and how to deal with these incompatibilities, possibly with defaulting or migrations. It may be useful to refer back to the goals and non-goals to assist in articulating the "why" behind your approach.
 
@@ -79,23 +78,27 @@ List crucial impacts and key questions, some of which may still be open. They li
 This will also help people understand the caveats to the proposal, other important details that didn't come across above, and alternatives that could be considered. It can also be a good place to talk about core concepts and how they relate. It can be helpful to explicitly list the pros and cons of each decision. Later, this information can be reused to update project documentation, guides, and Frequently Asked Questions (FAQs).
 
 ### Pros
+
 Pros are defined as the benefits and positive aspects of the design as described. It should further reinforce how and why the design meets its goals and intended outcomes. This is a good place to check for any assumptions that have been made in the design.
+
 ### Cons
+
 Cons are defined as the negative aspects or disadvantages of the design as described. This section has the potential to capture outstanding challenge areas or future improvements needed for the project and could be referenced in future PRs and issues. This is also a good place to check for any assumptions that have been made in the design.
+
 ## Risks and Mitigations
 
-Describe the risks of this proposal and how they can be mitigated. This should be broadly scoped and describe how it will impact the larger ecosystem and potentially adopters of the project; such as if adopters need to immediately update, or support a new port or protocol. It should include drawbacks to the proposed solution. 
+Describe the risks of this proposal and how they can be mitigated. This should be broadly scoped and describe how it will impact the larger ecosystem and potentially adopters of the project; such as if adopters need to immediately update, or support a new port or protocol. It should include drawbacks to the proposed solution.
 
 ### Security Considerations
 
 When attempting to identify security implications of the changes, consider the following questions:
+
 * Does the change alter the permissions or access of users, services, components - this could be an improvement or downgrade or even just a different way of doing it?
 * Does the change alter the flow of information, events, and logs stored, processed, or transmitted?
 * Does the change increase the 'surface area' exposed - meaning, if an operator of the project or user were to go rogue or be uninformed in its operation, do they have more areas that could be manipulated unfavorably?
 * What existing security features, controls, or boundaries would be affected by this change?
 
 This section can also be combined into the one above.
-
 
 ## (Optional) Future Milestones
 

--- a/DESIGN-PROPOSALS.md
+++ b/DESIGN-PROPOSALS.md
@@ -61,11 +61,11 @@ This is where we get down to the specifics of what the proposal actually is. It 
 
 This section should contain enough information to allow the following to occur:
 
-* potential contributors understand how the feature or change should be implemented
-* users or operators understand how the feature of change is expected to function and interact with other components of the project
-* users or operators can take action to pre-plan any needed changes within their architecture that impacted by the upcoming feature or change if it's approved for implementation
-* decisions or opinions on a specific approach are fully discussed and explained
-* users, operators, and contributors can gain a comprehensive understanding of compatibility of the feature or change with past releases of the project.
+- potential contributors understand how the feature or change should be implemented
+- users or operators understand how the feature of change is expected to function and interact with other components of the project
+- users or operators can take action to pre-plan any needed changes within their architecture that impacted by the upcoming feature or change if it's approved for implementation
+- decisions or opinions on a specific approach are fully discussed and explained
+- users, operators, and contributors can gain a comprehensive understanding of compatibility of the feature or change with past releases of the project.
 
 This may include API specs (though not always required), code snippets, data flow diagrams, sequence diagrams, etc.
 
@@ -93,10 +93,10 @@ Describe the risks of this proposal and how they can be mitigated. This should b
 
 When attempting to identify security implications of the changes, consider the following questions:
 
-* Does the change alter the permissions or access of users, services, components - this could be an improvement or downgrade or even just a different way of doing it?
-* Does the change alter the flow of information, events, and logs stored, processed, or transmitted?
-* Does the change increase the 'surface area' exposed - meaning, if an operator of the project or user were to go rogue or be uninformed in its operation, do they have more areas that could be manipulated unfavorably?
-* What existing security features, controls, or boundaries would be affected by this change?
+- Does the change alter the permissions or access of users, services, components - this could be an improvement or downgrade or even just a different way of doing it?
+- Does the change alter the flow of information, events, and logs stored, processed, or transmitted?
+- Does the change increase the 'surface area' exposed - meaning, if an operator of the project or user were to go rogue or be uninformed in its operation, do they have more areas that could be manipulated unfavorably?
+- What existing security features, controls, or boundaries would be affected by this change?
 
 This section can also be combined into the one above.
 

--- a/GOVERNANCE-elections.md
+++ b/GOVERNANCE-elections.md
@@ -36,21 +36,21 @@ evolve as the community and project change.
 
 The [TODO: PROJECTNAME] and its leadership embrace the following values:
 
-* Openness: Communication and decision-making happens in the open and is discoverable for future
+- Openness: Communication and decision-making happens in the open and is discoverable for future
   reference. As much as possible, all discussions and work take place in public
   forums and open repositories.
 
-* Fairness: All stakeholders have the opportunity to provide feedback and submit
+- Fairness: All stakeholders have the opportunity to provide feedback and submit
   contributions, which will be considered on their merits.
 
-* Community over Product or Company: Sustaining and growing our community takes
+- Community over Product or Company: Sustaining and growing our community takes
   priority over shipping code or sponsors' organizational goals.  Each
   contributor participates in the project as an individual.
 
-* Inclusivity: We innovate through different perspectives and skill sets, which
+- Inclusivity: We innovate through different perspectives and skill sets, which
   can only be accomplished in a welcoming and respectful environment.
 
-* Participation: Responsibilities within the project are earned through
+- Participation: Responsibilities within the project are earned through
   participation, and there is a clear path up the contributor ladder into leadership
   positions.
 
@@ -61,23 +61,23 @@ The following responsibilities and powers belong to the Steering Committee.
 Technical governance is expected to be performed by the Maintainers of the
 various project areas and subprojects, as defined in the appropriate OWNERS files.
 
-* Delegate ownership of, responsibility for and authority over areas of the
+- Delegate ownership of, responsibility for and authority over areas of the
   project to specific entities.
-* Define, evolve, and defend the vision, mission and the values of the project.
-* Charter and refine policy for defining new community groups, and establish
+- Define, evolve, and defend the vision, mission and the values of the project.
+- Charter and refine policy for defining new community groups, and establish
   transparency and accountability policies for such groups
-* Define and evolve project and group governance structures and policies.
-* Act as a final escalation point for disputes in any project repository or
+- Define and evolve project and group governance structures and policies.
+- Act as a final escalation point for disputes in any project repository or
   group.
-* Request funds and other support from the CNCF (e.g. marketing, press, etc.)
-* Coordinate with the CNCF regarding usage of the [TODO: PROJECTNAME] brand and deciding
+- Request funds and other support from the CNCF (e.g. marketing, press, etc.)
+- Coordinate with the CNCF regarding usage of the [TODO: PROJECTNAME] brand and deciding
   project scope, core requirements, and conformance, as well as how that brand
   can be used in relation to other efforts or vendors.
-* Decide, for the purpose of elections, who is a member of standing, and what
+- Decide, for the purpose of elections, who is a member of standing, and what
   privileges that entails.
-* Control and delegate access to and establish processes regarding all project
+- Control and delegate access to and establish processes regarding all project
   repositories, resources, and assets.
-* Appointing the members of the Code of Conduct Committee in order to ensure
+- Appointing the members of the Code of Conduct Committee in order to ensure
   responsiveness, diversity, and good judgement.
 
 ## Delegated authority

--- a/GOVERNANCE-elections.md
+++ b/GOVERNANCE-elections.md
@@ -54,7 +54,6 @@ The [TODO: PROJECTNAME] and its leadership embrace the following values:
   participation, and there is a clear path up the contributor ladder into leadership
   positions.
 
-
 ## Charter
 
 The following responsibilities and powers belong to the Steering Committee.
@@ -116,7 +115,6 @@ first name):
 
 | &nbsp;                                                         | Member           | Organization |
 | -------------------------------------------------------------- | ---------------- | ------------ |
-
 
 ## Decision process
 

--- a/GOVERNANCE-maintainer.md
+++ b/GOVERNANCE-maintainer.md
@@ -21,21 +21,21 @@ This governance explains how the project is run.
 
 The [TODO: PROJECTNAME] and its leadership embrace the following values:
 
-* Openness: Communication and decision-making happens in the open and is discoverable for future
+- Openness: Communication and decision-making happens in the open and is discoverable for future
   reference. As much as possible, all discussions and work take place in public
   forums and open repositories.
 
-* Fairness: All stakeholders have the opportunity to provide feedback and submit
+- Fairness: All stakeholders have the opportunity to provide feedback and submit
   contributions, which will be considered on their merits.
 
-* Community over Product or Company: Sustaining and growing our community takes
+- Community over Product or Company: Sustaining and growing our community takes
   priority over shipping code or sponsors' organizational goals.  Each
   contributor participates in the project as an individual.
 
-* Inclusivity: We innovate through different perspectives and skill sets, which
+- Inclusivity: We innovate through different perspectives and skill sets, which
   can only be accomplished in a welcoming and respectful environment.
 
-* Participation: Responsibilities within the project are earned through
+- Participation: Responsibilities within the project are earned through
   participation, and there is a clear path up the contributor ladder into leadership
   positions.
 
@@ -63,15 +63,15 @@ is the governing body for the project.
 
 To become a Maintainer you need to demonstrate the following:
 
-* commitment to the project:
-  * participate in discussions, contributions, code and documentation reviews
+- commitment to the project:
+  - participate in discussions, contributions, code and documentation reviews
       for [TODO: Time Period] or more,
-  * perform reviews for [TODO:Number] non-trivial pull requests,
-  * contribute [TODO:Number] non-trivial pull requests and have them merged,
-* ability to write quality code and/or documentation,
-* ability to collaborate with the team,
-* understanding of how the team works (policies, processes for testing and code review, etc),
-* understanding of the project's code base and coding and documentation style.
+  - perform reviews for [TODO:Number] non-trivial pull requests,
+  - contribute [TODO:Number] non-trivial pull requests and have them merged,
+- ability to write quality code and/or documentation,
+- ability to collaborate with the team,
+- understanding of how the team works (policies, processes for testing and code review, etc),
+- understanding of the project's code base and coding and documentation style.
 <!-- add any additional Maintainer requirements here -->
 
 A new Maintainer must be proposed by an existing maintainer by sending a message to the

--- a/GOVERNANCE-maintainer.md
+++ b/GOVERNANCE-maintainer.md
@@ -63,16 +63,16 @@ is the governing body for the project.
 
 To become a Maintainer you need to demonstrate the following:
 
-  * commitment to the project:
-    * participate in discussions, contributions, code and documentation reviews
+* commitment to the project:
+  * participate in discussions, contributions, code and documentation reviews
       for [TODO: Time Period] or more,
-    * perform reviews for [TODO:Number] non-trivial pull requests,
-    * contribute [TODO:Number] non-trivial pull requests and have them merged,
-  * ability to write quality code and/or documentation,
-  * ability to collaborate with the team,
-  * understanding of how the team works (policies, processes for testing and code review, etc),
-  * understanding of the project's code base and coding and documentation style.
-  <!-- add any additional Maintainer requirements here -->
+  * perform reviews for [TODO:Number] non-trivial pull requests,
+  * contribute [TODO:Number] non-trivial pull requests and have them merged,
+* ability to write quality code and/or documentation,
+* ability to collaborate with the team,
+* understanding of how the team works (policies, processes for testing and code review, etc),
+* understanding of the project's code base and coding and documentation style.
+<!-- add any additional Maintainer requirements here -->
 
 A new Maintainer must be proposed by an existing maintainer by sending a message to the
 [developer mailing list](TODO: List Link). A simple majority vote of existing Maintainers
@@ -87,10 +87,10 @@ and invited to the [private maintainer mailing list](TODO).
 Maintainers may resign at any time if they feel that they will not be able to
 continue fulfilling their project duties.
 
-Maintainers may also be removed after being inactive, failure to fulfill their 
+Maintainers may also be removed after being inactive, failure to fulfill their
 Maintainer responsibilities, violating the Code of Conduct, or other reasons.
-Inactivity is defined as a period of very low or no activity in the project 
-for a year or more, with no definite schedule to return to full Maintainer 
+Inactivity is defined as a period of very low or no activity in the project
+for a year or more, with no definite schedule to return to full Maintainer
 activity.
 
 A Maintainer may be removed at any time by a 2/3 vote of the remaining maintainers.
@@ -132,7 +132,7 @@ with the CNCF Code of Conduct Committee in resolving it.
 
 The Maintainers will appoint a Security Response Team to handle security reports.
 This committee may simply consist of the Maintainer Council themselves.  If this
-responsibility is delegated, the Maintainers will appoint a team of at least two 
+responsibility is delegated, the Maintainers will appoint a team of at least two
 contributors to handle it.  The Maintainers will review who is assigned to this
 at least once a year.
 
@@ -141,7 +141,7 @@ holes and breaches according to the [security policy](TODO:Link to security.md).
 
 ## Voting
 
-While most business in [TODO: PROJECTNAME] is conducted by "[lazy consensus](https://community.apache.org/committers/lazyConsensus.html)", 
+While most business in [TODO: PROJECTNAME] is conducted by "[lazy consensus](https://community.apache.org/committers/lazyConsensus.html)",
 periodically the Maintainers may need to vote on specific actions or changes.
 A vote can be taken on [the developer mailing list](TODO) or
 [the private Maintainer mailing list](TODO) for security or conduct matters.  
@@ -149,10 +149,10 @@ Votes may also be taken at [the developer meeting](TODO).  Any Maintainer may
 demand a vote be taken.
 
 Most votes require a simple majority of all Maintainers to succeed, except where
-otherwise noted.  Two-thirds majority votes mean at least two-thirds of all 
+otherwise noted.  Two-thirds majority votes mean at least two-thirds of all
 existing maintainers.
 
 ## Modifying this Charter
 
-Changes to this Governance and its supporting documents may be approved by 
+Changes to this Governance and its supporting documents may be approved by
 a 2/3 vote of the Maintainers.

--- a/GOVERNANCE-subprojects.md
+++ b/GOVERNANCE-subprojects.md
@@ -46,6 +46,7 @@ The [TODO: PROJECTNAME] and its leadership embrace the following values:
 [Instructions](https://contribute.cncf.io/maintainers/github/templates/required/governance-subprojects/#subprojects)
 
 [TODO:PROJECTNAME]'s Subprojects are:
+
 * [TODO:LIST OF SUBPROJECTS]
 
 All active Maintainers of each subproject, as defined in the Contributor Ladder, are
@@ -61,9 +62,9 @@ activities:
 * Supporting the Code of Conduct within their subproject and referring violations
   to the Code of Conduct Committee.
 
-Additionally, each subproject's Maintainer Committee will select, by majority vote, 
-one representative to the Steering Committee.  This representative 
-need not be a member of the subproject's Maintainer Committee, and will be 
+Additionally, each subproject's Maintainer Committee will select, by majority vote,
+one representative to the Steering Committee.  This representative
+need not be a member of the subproject's Maintainer Committee, and will be
 replaced or renewed by the committee annually.
 
 Should a member of the Maintainer Committee cease being active in the subproject,
@@ -104,14 +105,14 @@ that is open to all contributors.  The Committee may hold additional, closed mee
 in order to discuss non-public issues such as security exploits, CoC enforcement,
 and legal questions.
 
-Steering Committee members are expected to advocate for all of [TODO:PROJECTNAME], 
-not just certain subprojects or corporate sponsors, comply with and support the 
-Code of Conduct, and be professional and compassionate in all of their dealings 
+Steering Committee members are expected to advocate for all of [TODO:PROJECTNAME],
+not just certain subprojects or corporate sponsors, comply with and support the
+Code of Conduct, and be professional and compassionate in all of their dealings
 with project participants.
 
 ### Steering Committee Elections
 
-The Community Representative(s) will be elected by the collective Organization 
+The Community Representative(s) will be elected by the collective Organization
 Members of all subprojects, as defined in the Contributor Ladder.  They
 will be elected annually.
 
@@ -137,11 +138,11 @@ community meeting.
 
 In order to review and enforce the Code of Conduct, the Steering Committee selects
 [TODO:Number, suggest "3 to 5"] people to be on the Code of Conduct Committee.  
-These individuals will be chosen based on their community management and code of 
-conduct experience, with diverse representation across the committee, including 
-employer, gender, race, background, and region of the world.  To avoid fatigue, 
-the Steering Committee will replace at least [TODO:Number] member of the CoC 
-Committee each year.  Members of the committee do not need to be members of 
+These individuals will be chosen based on their community management and code of
+conduct experience, with diverse representation across the committee, including
+employer, gender, race, background, and region of the world.  To avoid fatigue,
+the Steering Committee will replace at least [TODO:Number] member of the CoC
+Committee each year.  Members of the committee do not need to be members of
 [TODO:PROJECTNAME] if they have sufficient other expertise.
 
 The CoC Committee will receive reports of conduct violations confidentially,
@@ -186,19 +187,19 @@ per year to determine if they have matured to full subproject status.
 [Instructions](https://contribute.cncf.io/maintainers/github/templates/required/governance-subprojects/#adding-and-removing-subprojects)
 
 In some cases, projects will become inactive or unmaintainable, or wish to separate
-from [TODO:PROJECTNAME]. Any Steering Committee member may propose removal of a 
+from [TODO:PROJECTNAME]. Any Steering Committee member may propose removal of a
 project on these grounds, and Steering can confirm this with a majority vote.
 
-Subprojects which still have contributors will then be moved to a repository in 
+Subprojects which still have contributors will then be moved to a repository in
 their own namespace. Projects which have ceased all activity are moved to a
 [TODO:Name of archive namespace] namespace.
 
 ## Amendments
 
-This governance document, and other governance documents of [TODO:PROJECTNAME], 
-can be amended with a 2/3 majority vote of the Steering Committee.  Unless time is of 
-the essence, the amendment should be circulated in the contributor community for 
+This governance document, and other governance documents of [TODO:PROJECTNAME],
+can be amended with a 2/3 majority vote of the Steering Committee.  Unless time is of
+the essence, the amendment should be circulated in the contributor community for
 comment for at least one week before voting.
 
-Should an amendment be required in order to elect a steering committee, it may 
+Should an amendment be required in order to elect a steering committee, it may
 be amended via a majority vote all of the collective subproject maintainers.

--- a/GOVERNANCE-subprojects.md
+++ b/GOVERNANCE-subprojects.md
@@ -23,21 +23,21 @@ of [TODO:Goals of umbrella project].  Our governance reflects this federated str
 
 The [TODO: PROJECTNAME] and its leadership embrace the following values:
 
-* Openness: Communication and decision-making happens in the open and is discoverable for future
+- Openness: Communication and decision-making happens in the open and is discoverable for future
   reference. As much as possible, all discussions and work take place in public
   forums and open repositories.
 
-* Fairness: All stakeholders have the opportunity to provide feedback and submit
+- Fairness: All stakeholders have the opportunity to provide feedback and submit
   contributions, which will be considered on their merits.
 
-* Community over Product or Company: Sustaining and growing our community takes
+- Community over Product or Company: Sustaining and growing our community takes
   priority over shipping code or sponsors' organizational goals.  Each
   contributor participates in the project as an individual.
 
-* Inclusivity: We innovate through different perspectives and skill sets, which
+- Inclusivity: We innovate through different perspectives and skill sets, which
   can only be accomplished in a welcoming and respectful environment.
 
-* Participation: Responsibilities within the project are earned through
+- Participation: Responsibilities within the project are earned through
   participation, and there is a clear path up the contributor ladder into leadership
   positions.
 
@@ -47,19 +47,19 @@ The [TODO: PROJECTNAME] and its leadership embrace the following values:
 
 [TODO:PROJECTNAME]'s Subprojects are:
 
-* [TODO:LIST OF SUBPROJECTS]
+- [TODO:LIST OF SUBPROJECTS]
 
 All active Maintainers of each subproject, as defined in the Contributor Ladder, are
 members of that subproject's Maintainer Committee, which governs that project.  The
 subproject's Maintainer Committee is responsible for the following project governance
 activities:
 
-* Ensuring that the subproject creates and publishes regular releases;
-* Holding regular, subproject-wide discussions on issues and planning;
-* Monthly review of project contributors for advancement on the Contributor Ladder;
-* Making final decisions on subproject changes that involve controversial trade-offs;
-* Responding to security compromise reports;
-* Supporting the Code of Conduct within their subproject and referring violations
+- Ensuring that the subproject creates and publishes regular releases;
+- Holding regular, subproject-wide discussions on issues and planning;
+- Monthly review of project contributors for advancement on the Contributor Ladder;
+- Making final decisions on subproject changes that involve controversial trade-offs;
+- Responding to security compromise reports;
+- Supporting the Code of Conduct within their subproject and referring violations
   to the Code of Conduct Committee.
 
 Additionally, each subproject's Maintainer Committee will select, by majority vote,
@@ -79,25 +79,25 @@ majority vote of the Steering Committee.
 The overall [TODO:PROJECTNAME] project is governed by a Steering
 Committee, which is selected as follows:
 
-* One Maintainer representative from each member subproject
-* [TODO:Number] general "Community Representatives"
+- One Maintainer representative from each member subproject
+- [TODO:Number] general "Community Representatives"
 
 ### Steering Committee Duties
 
 The Steering Committee is responsible for the following tasks, any of which may
 be delegated to a person or group selected by the committee:
 
-* Reviewing and deciding on new projects to add to [TODO:PROJECTNAME]
-* Communicating with the CNCF on behalf of the project
-* Arbitrating inter-project disagreements
-* Selecting the Code of Conduct Committee and ratifying CoC judgements
-* Removing projects which have become inactive
-* Acting on escalated security or code quality issues
-* Resolving issues that individual projects are unable to resolve
-* Administering project infrastructure, intellectual property, and resources
-* Determining overall direction for advocacy and marketing
-* Issuing statements on behalf of [TODO:PROJECTNAME] and its subprojects
-* Reviewing and approving Contributor Ladder advancement for participants whose
+- Reviewing and deciding on new projects to add to [TODO:PROJECTNAME]
+- Communicating with the CNCF on behalf of the project
+- Arbitrating inter-project disagreements
+- Selecting the Code of Conduct Committee and ratifying CoC judgements
+- Removing projects which have become inactive
+- Acting on escalated security or code quality issues
+- Resolving issues that individual projects are unable to resolve
+- Administering project infrastructure, intellectual property, and resources
+- Determining overall direction for advocacy and marketing
+- Issuing statements on behalf of [TODO:PROJECTNAME] and its subprojects
+- Reviewing and approving Contributor Ladder advancement for participants whose
   work falls outside of defined subprojects
 
 In performance of these duties, the Steering Committee will hold a monthly meeting
@@ -163,10 +163,10 @@ During the monthly Steering meeting, any project member may recommend projects
 to become a subproject of [TODO:PROJECTNAME].  These projects should have the following
 characteristics:
 
-* Have a mission of [TODO:Goals of umbrella project];
-* Are appropriately licensed and governed or willing to become so;
-* Are under active development;
-* Consist of high quality code and designs.
+- Have a mission of [TODO:Goals of umbrella project];
+- Are appropriately licensed and governed or willing to become so;
+- Are under active development;
+- Consist of high quality code and designs.
 
 Before submitting an application to the Steering Committee, the applying project
 must hold an internal consensus vote of all major contributors to join

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,3 +1,5 @@
+# Maintainers
+
 The current Maintainers Group for the [TODO: Projectname] Project consists of:
 
 | Name | Employer | Responsibilities |

--- a/README-template.md
+++ b/README-template.md
@@ -9,9 +9,11 @@ before it is ready to use. Read the markdown comments, `<!-- COMMENT -->`, for
 additional guidance. The raw markdown uses `TODO` to identify areas that
 require customization.  Replace [TODO: PROJECTNAME] with the name of your project.
 
+<!-- markdownlint-disable-file MD025 -->
+
 <!-- template begins here-->
 
-# Welcome to the [TODO:Projectname] Project!
+# Welcome to the [TODO:Projectname] Project
 
 <!-- Mission Statement -->
 <!-- More information about crafting your mission statement with examples -->
@@ -34,7 +36,7 @@ include:
 * quick installation/build instructions
 * a few simple examples of use
 * basic prerequisites
---> 
+-->
 
 ## Contributing
 <!-- Template: https://github.com/cncf/project-template/blob/main/CONTRIBUTING.md -->
@@ -57,7 +59,6 @@ project will implement or has implemented:
 * [TODO: High-level Item 2]
 * [TODO: High-level Item 3]
 
-
 ### Out of Scope
 
 [TODO: PROJECTNAME] will be used in a cloud native environment with other
@@ -65,7 +66,6 @@ tools. The following specific functionality will therefore not be incorporated:
 
 * [TODO: Excluded function 1]
 * [TODO: Excluded function 2]
-
 
 [TODO: PROJECTNAME] implements [TODO: List of major features, existing or
 planned], through [TODO: Implementation
@@ -84,7 +84,7 @@ prospective contributors know when and where to engage with you. -->
 * User Mailing List:
 * Developer Mailing List:
 * Slack Channel:
-* Public Meeting Schedule and Links: 
+* Public Meeting Schedule and Links:
 * Social Media:
 * Other Channel(s), If Any:
 

--- a/README-template.md
+++ b/README-template.md
@@ -33,9 +33,9 @@ Implementation, strategy and architecture].
 project here and link to other docs with more detail as needed.  Depending on
 the nature of the project and its current development status, this might
 include:
-* quick installation/build instructions
-* a few simple examples of use
-* basic prerequisites
+- quick installation/build instructions
+- a few simple examples of use
+- basic prerequisites
 -->
 
 ## Contributing
@@ -55,17 +55,17 @@ CONTRIBUTING.md).
 [TODO: PROJECTNAME] is intended to [TODO: Core functionality]. As such, the
 project will implement or has implemented:
 
-* [TODO: High-level Item 1]
-* [TODO: High-level Item 2]
-* [TODO: High-level Item 3]
+- [TODO: High-level Item 1]
+- [TODO: High-level Item 2]
+- [TODO: High-level Item 3]
 
 ### Out of Scope
 
 [TODO: PROJECTNAME] will be used in a cloud native environment with other
 tools. The following specific functionality will therefore not be incorporated:
 
-* [TODO: Excluded function 1]
-* [TODO: Excluded function 2]
+- [TODO: Excluded function 1]
+- [TODO: Excluded function 2]
 
 [TODO: PROJECTNAME] implements [TODO: List of major features, existing or
 planned], through [TODO: Implementation
@@ -81,12 +81,12 @@ prospective contributors know when and where to engage with you. -->
 
 [TODO: Details (with links) to meetings, mailing lists, Slack, and any other communication channels]
 
-* User Mailing List:
-* Developer Mailing List:
-* Slack Channel:
-* Public Meeting Schedule and Links:
-* Social Media:
-* Other Channel(s), If Any:
+- User Mailing List:
+- Developer Mailing List:
+- Slack Channel:
+- Public Meeting Schedule and Links:
+- Social Media:
+- Other Channel(s), If Any:
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ when you view the markdown file in GitHub unless you view the raw text.
 
 ## Required Templates
 
-* [LICENSE](LICENSE)
-* [CONTRIBUTING.md](CONTRIBUTING.md)
-* [README-template.md](README-template.md)
+- [LICENSE](LICENSE)
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [README-template.md](README-template.md)
 
 [template-repo]: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template
 [contrib-strat]: https://github.com/cncf/sig-contributor-strategy/blob/master/README.md

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ that you need.
 
 Each file is a template with instructions to customize the contents for your project.
 Most files use comments with TODO to call out where you need to make changes. We recommend
-viewing the files in raw or text form so that you can see the comments. 
+viewing the files in raw or text form so that you can see the comments.
 
 For example in markdown files, we use `<!-- TODO: ... -->` to provide additional
 guidance or indicate where action is required but you won't see those comments

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -34,17 +34,17 @@ Be welcoming and inclusive. You should proactively ensure that the author is suc
 
 Avoid burnout by enforcing healthy boundaries. Here are some examples of how a reviewer is encouraged to act to take care of themselves:
 
-* Authors should meet baseline expectations when submitting a pull request, such as writing tests.
-* If your availability changes, you can step down from a pull request and have someone else assigned.
-* If interactions with an author are not following code of conduct, close the PR and raise it up with your Code of Conduct committee or point of contact. It's not your job to coax people into behaving.
+- Authors should meet baseline expectations when submitting a pull request, such as writing tests.
+- If your availability changes, you can step down from a pull request and have someone else assigned.
+- If interactions with an author are not following code of conduct, close the PR and raise it up with your Code of Conduct committee or point of contact. It's not your job to coax people into behaving.
 
 ### Trust
 
 Be trustworthy. During a review, your actions both build and help maintain the trust that the community has placed in this project. Below are examples of ways that we build trust:
 
-* **Transparency** - If a pull request won't be merged, clearly say why and close it. If a pull request won't be reviewed for a while, let the author know so they can set expectations and understand why it's blocked.
-* **Integrity** - Put the project's best interests ahead of personal relationships or company affiliations when deciding if a change should be merged.
-* **Stability** - Only merge when then change won't negatively impact project stability. It can be tempting to merge a pull request that doesn't meet our quality standards, for example when the review has been delayed, or because we are trying to deliver new features quickly, but regressions can significantly hurt trust in our project.
+- **Transparency** - If a pull request won't be merged, clearly say why and close it. If a pull request won't be reviewed for a while, let the author know so they can set expectations and understand why it's blocked.
+- **Integrity** - Put the project's best interests ahead of personal relationships or company affiliations when deciding if a change should be merged.
+- **Stability** - Only merge when then change won't negatively impact project stability. It can be tempting to merge a pull request that doesn't meet our quality standards, for example when the review has been delayed, or because we are trying to deliver new features quickly, but regressions can significantly hurt trust in our project.
 
 ## Process
 
@@ -68,6 +68,6 @@ Below are a set of common questions that apply to all pull requests:
 
 Reviewers are encouraged to read the following articles for help with common reviewer tasks:
 
-* [The Art of Closing: How to closing an unfinished or rejected pull request](https://blog.jessfraz.com/post/the-art-of-closing/)
-* [Kindness and Code Reviews: Improving the Way We Give Feedback](https://product.voxmedia.com/2018/8/21/17549400/kindness-and-code-reviews-improving-the-way-we-give-feedback)
-* [Code Review Guidelines for Humans: Examples of good and back feedback](https://phauer.com/2018/code-review-guidelines/#code-reviews-guidelines-for-the-reviewer)
+- [The Art of Closing: How to closing an unfinished or rejected pull request](https://blog.jessfraz.com/post/the-art-of-closing/)
+- [Kindness and Code Reviews: Improving the Way We Give Feedback](https://product.voxmedia.com/2018/8/21/17549400/kindness-and-code-reviews-improving-the-way-we-give-feedback)
+- [Code Review Guidelines for Humans: Examples of good and back feedback](https://phauer.com/2018/code-review-guidelines/#code-reviews-guidelines-for-the-reviewer)

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -22,7 +22,6 @@ The reviewer role is distinct from the maintainer role. Reviewers can approve a 
 
 [Instructions](https://contribute.cncf.io/maintainers/github/templates/recommended/reviewing/#values)
 
-
 All reviewers must abide by the [Code of Conduct](CODE_OF_CONDUCT.md) and are also protected by it. A reviewer should not tolerate poor behavior and is encouraged to report any behavior that violates the Code of Conduct. All of our values listed above are distilled from our Code of Conduct.
 
 Below are concrete examples of how it applies to code review specifically:
@@ -53,7 +52,6 @@ Be trustworthy. During a review, your actions both build and help maintain the t
 
 ⚠️ **Define your project's review process**
 
-
 ## Checklist
 
 [Instructions](https://contribute.cncf.io/maintainers/github/templates/recommended/reviewing/#checklist)
@@ -65,7 +63,6 @@ Below are a set of common questions that apply to all pull requests:
 - [ ] Does the affected code have corresponding tests?
 - [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
 - [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
-
 
 ## Reading List
 


### PR DESCRIPTION
Closes #1 

Adds the GitHub action to run Markdown lint on all PRs.  This MR also fixes the issues found from the CNCF template that did not pass markdownlint.

We still need to determine if we need a style guide for the Markdown files.