### PR TITLE
docs: update WG chair list

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The CNCF Artifacts Working Group is under the App Delivery Technical Advisory Gr
 
 ## Chairs
 
-- Alex Flom (@afflom)
+- Andrew Block (@sabre1041)
 - Ramkumar Chinchani (@rchincha)
 
 ## Getting Started


### PR DESCRIPTION
Andrew Block (@sabre1041) has been nominated to take Alex Flom's place.

https://github.com/cncf/tag-app-delivery/issues/516